### PR TITLE
[fix] 모바일 환경에서 지도 스냅샷 타이밍 이슈

### DIFF
--- a/daengdong/types/global.d.ts
+++ b/daengdong/types/global.d.ts
@@ -33,6 +33,7 @@ declare global {
         };
         initNaverMap?: () => void;
         getWalkSnapshotBlob?: () => Promise<Blob | null>;
+        isWalkSnapshotReady?: boolean;
     }
 }
 


### PR DESCRIPTION
## 요약
모바일 환경에서 산책 종료 시 지도 스냅샷이 간헐적으로 실패하는 문제 발생 
<img height="400" alt="image" src="https://github.com/user-attachments/assets/4b522b97-30f8-49ca-a553-aed6d495fef8" />

## 문제 상황
- 모바일에서 산책 종료 시 지도 스냅샷 생성 간헐적으로 실패
- 에러 로그 : `지도 스냅샷 생성 실패 : getWalkSnapshotBlob이 정의되지 않았거나 null을 반환했습니다.`
- 데스크톱에서는 발생하지 않음 

## 원인 
### 타이밍 Race Condition
- 모바일에서 지도 렌더링(WebGL/Canvas)이 데스크톱보다 느림
- 기존 1000ms 대기 시간이 모바일 렌더링 완료에서는 부족함
- 캔버스가 준비되기 전에 `getWalkSnapshotBlob()` 호출
- 결과적으로 `null` 반환 또는 `undefined` 상태 발생

## 해결 방법
### 1. 준비 상태 추적 및 노출
- window.isWalkSnapshotReady 상태 추가
- 외부에서 스냅샷 준비 여부를 확인할 수 있도록 노출
### 2. 폴링 매커니즘 구현
- requestAnimationFrame 기반 효율적인 폴링
- 최대 5초 대기 
- 준비 완료 시 즉시 스냅샷 생성
### 3. 모바일 최적화
- 초기 대기 시간 : 1000ms -> 1500ms 
- 모바일 네트워크 및 렌더링 속도 고려
### 4. 검증 로직 추가 
- 함수 존재 여부 체크
- Blob 유효성 검증 (null 체크, size > 0)
- 상세한 에러 로깅
### 4. 우아한 성능 저하법
- 스냅샷 실패해도 산책 종료는 정상 진행
- 사용자 경험에 치명적 영향없는 기능으로 판단

## 개선 효과 
### Before
```
산책 종료 -> 1000ms 대기 -> 스냅샷 시도 -> 실패 
``` 
### After
```
산책 종료 -> 1500ms 대기 -> 준비상태 폴링(최대 5초) -> 성공 (타임아웃 시에도 산책 완료 보장)
``` 

## 테스트 방법
### Chrome DevTools 시뮬레이션
- 네트워크 3G 설정
- 콘솔 로그 확인

### 실제 모바일 기기
- Chrome DevTools USB 디버깅 방식
- 콘솔 로그 /네트워크 탭 확인 
-  Android Chrome

## 리뷰 포인트
- 폴링 최대 시간 (5초)이 적절한지 
- 초기 대기시간 1500ms로 늘린 것이 적절한지

