### PR TITLE
fix: 정적 지도 오버레이 위치 정확도 개선

### DIFF
--- a/daengdong/types/naver-maps.d.ts
+++ b/daengdong/types/naver-maps.d.ts
@@ -10,6 +10,10 @@ declare global {
         Marker: new (options: NaverMarkerOptions) => NaverMarker;
         Polygon: new (options: NaverPolygonOptions) => NaverPolygon;
         Polyline: new (options: NaverPolylineOptions) => NaverPolyline;
+        TransCoord: {
+          fromLatLngToEPSG5179: (latlng: NaverLatLng) => NaverPoint;
+          fromEPSG5179ToLatLng: (point: NaverPoint) => NaverLatLng;
+        };
         Event: {
           addListener: (target: unknown, eventName: string, handler: () => void) => NaverEventListener;
           removeListener: (listener: NaverEventListener) => void;


### PR DESCRIPTION
**문제:** 정적 지도의 블록/경로가 실제 위치보다 오른쪽 위로 그려짐
- Web Mercator 투영법과 Naver Maps Static API 좌표계 불일치
**해결:**
- Naver Maps 공식 스케일 공식 적용
  - Level 20: 1픽셀 = 0.0745m
  - Level n: 1픽셀 = 0.0745 × 2^(20-n) 미터
- 위도에 따른 경도 스케일 보정 (cos(latitude))
- 미터 기반 정확한 좌표 변환
**적용 파일:**
- [features/walk/ui/WalkSnapshotRenderer.tsx](cci:7://file:///Users/sian/Documents/GitHub/20-team-daeng-ddang-fe/daengdong/features/walk/ui/WalkSnapshotRenderer.tsx:0:0-0:0)
### 3. 기타 개선
- `TransCoord` 타입 정의 추가 ([types/naver-maps.d.ts](cci:7://file:///Users/sian/Documents/GitHub/20-team-daeng-ddang-fe/daengdong/types/naver-maps.d.ts:0:0-0:0))
- 돌발미션 타이밍 테스트용 변경 (10초, 2분, 4분)
- 비디오 MIME 타입 자동 감지 (iOS: video/mp4, Android: video/webm)
## 🧪 Testing
- [x] iOS Safari에서 표정분석 비디오 녹화 및 업로드
- [x] iOS Safari에서 돌발미션 비디오 녹화 및 업로드
- [x] 정적 지도 오버레이 위치 확인
- [x] 다양한 줌 레벨에서 좌표 정확도 검증
## 🔗 Related Issues
- iOS 비디오 업로드 0바이트 문제
- 정적 지도 오버레이 위치 불일치
## 📝 Notes
- iOS Safari의 MediaRecorder는 timeslice 없이 호출 시 데이터를 수집하지 않는 버그가 있음
- Naver Maps Static API는 공식 스케일 공식을 사용하여 정확한 좌표 변환 가능
- 정적 지도 좌표 변환은 이론적으로 정확하나, 지구 곡률 및 타일 경계로 인해 미세한 오차 존재 가능 (서비스에는 무관)